### PR TITLE
Replace installed label with restart notif

### DIFF
--- a/data/interfaces.txt
+++ b/data/interfaces.txt
@@ -422,6 +422,16 @@ interface "plugins"
 		center -300 -150
 		dimensions 90 30
 		color bright
+	visible if "show plugins changed"
+	label "Restart to apply changes"
+		from -225 -236
+		align top left
+		color "plugin reload required"
+	visible if "!show plugins changed"
+	label "Installed Plugins:"
+		from -225 -236
+		align top left
+		color bright
 
 
 
@@ -434,17 +444,6 @@ interface "preferences"
 		dimensions 0 -200
 		color "energy"
 		size 3
-	visible if "show plugins changed"
-	sprite "ui/planet dialog button"
-		center 0 210
-	label "Restart game"
-		center 0 201
-		dimensions 140 40
-		color "plugin reload required"
-	label "to reload plugins."
-		center 0 219
-		dimensions 140 40
-		color "plugin reload required"
 
 
 

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -84,11 +84,11 @@ void PreferencesPanel::Draw()
 
 	Information info;
 	info.SetBar("volume", Audio::Volume());
+	if(Plugins::HasChanged())
+		info.SetCondition("show plugins changed");
 	GameData::Interfaces().Get("menu background")->Draw(info, this);
 	string pageName = (page == 'c' ? "controls" : page == 's' ? "settings" : "plugins");
 	GameData::Interfaces().Get(pageName)->Draw(info, this);
-	if(Plugins::HasChanged())
-		info.SetCondition("show plugins changed");
 	GameData::Interfaces().Get("preferences")->Draw(info, this);
 
 	zones.clear();
@@ -602,8 +602,7 @@ void PreferencesPanel::DrawPlugins()
 	// Table is at -110 while checkbox is at -130
 	table.DrawAt(Point(-110, firstY));
 	table.DrawUnderline(medium);
-	table.Draw("Installed plugins:", bright);
-	table.DrawGap(5);
+	table.DrawGap(25);
 
 	const Font &font = FontSet::Get(14);
 


### PR DESCRIPTION
Moves the condition check for changed plugins further up so all interface files can use it, then swaps the "Installed Plugins" label for the restart notification rather than having a button-looking label, as discussed on the Discord.