### PR TITLE
fix the logic

### DIFF
--- a/source/Ship.h
+++ b/source/Ship.h
@@ -211,11 +211,6 @@ public:
 	// Find out what fraction of the scan is complete.
 	double CargoScanFraction() const;
 	double OutfitScanFraction() const;
-	// Track scan complete
-	void CargoScannedBy(const Government *gov);
-	void OutfitScannedBy(const Government *gov);
-	bool CargoScanCompletedBy(const Government *gov) const;
-	bool OutfitScanCompletedBy(const Government *gov) const;
 
 	// Fire any weapons that are ready to fire. If an anti-missile is ready,
 	// instead of firing here this function returns true and it can be fired if
@@ -499,9 +494,6 @@ private:
 	// Cached values for figuring out when anti-missile is in range.
 	double antiMissileRange = 0.;
 	double weaponRadius = 0.;
-	// Track ally government surveillance on this ship.
-	std::vector<const Government *> cargoScannedBy;
-	std::vector<const Government *> outfitScannedBy;
 	// Cargo and outfit scanning takes time.
 	double cargoScan = 0.;
 	double outfitScan = 0.;

--- a/source/ShipEvent.h
+++ b/source/ShipEvent.h
@@ -66,7 +66,11 @@ public:
 		// you had with the given government, first.
 		ATROCITY = (1 << 8),
 		// This ship just jumped into a different system.
-		JUMP = (1 << 9)
+		JUMP = (1 << 9),
+		// This ship is currently scanning that ship's outfits or cargo.
+		SCANNING = (1 << 10),
+		// This ship stopped scanning, because it's out of range or because it's done scanning.
+		STOPPED_SCANNING = (1 << 11)
 	};
 
 


### PR DESCRIPTION
use SCANNING and STOPPED_SCANNING ShipEvents to only have one NPC of any given gov scanning  a ship at a time

removed all previous logic because it wasnt doing anything

note: we can talk about this, I want to be sure you understand this before merging it